### PR TITLE
Added Expectation-Maximization Implementation for Spatial Correlations

### DIFF
--- a/CellReg/compute_spatial_correlations_model.m
+++ b/CellReg/compute_spatial_correlations_model.m
@@ -1,9 +1,9 @@
-function [spatial_correlations_model_parameters,p_same_given_spatial_correlation,spatial_correlations_distribution,spatial_correlations_model_same_cells,spatial_correlations_model_different_cells,spatial_correlations_model_weighted_sum,MSE_spatial_correlations_model,spatial_correlation_intersection]=compute_spatial_correlations_model(neighbors_spatial_correlations,centers_of_bins)
+function [spatial_correlations_model_parameters,p_same_given_spatial_correlation,spatial_correlations_distribution,spatial_correlations_model_same_cells,spatial_correlations_model_different_cells,spatial_correlations_model_weighted_sum,MSE_spatial_correlations_model,spatial_correlation_intersection]=jeev_compute_spatial_correlations_model(neighbors_spatial_correlations,centers_of_bins)
 % This function recieves the distribution of spatial correlations for all
 % neighboring cells-pairs across sessions, and computes a probabilistic
 % model by finding the weighted sum of same cells and different cells that
-% best fit the data. Same cells are modeled as a lognormal distribution.
-% Different cells are modeled as a betha distribution.
+% best fit the data via Expectation-Maximization. Same cells are modeled as
+%a lognormal distribution. Different cells are modeled as a betha distribution.
 
 % Inputs:
 % 1. neighbors_spatial_correlations - all neighboring cell-pairs
@@ -19,6 +19,9 @@ function [spatial_correlations_model_parameters,p_same_given_spatial_correlation
 % 7. MSE_spatial_correlations_model
 % 8. spatial_correlation_intersection - the correlation for which same cells are
 % equal to different cells (P_same=0.5)
+same_model =@(x,sln,mln)( (1./(x*sln*sqrt(2*pi))).* exp(-0.5*(1/(sln^2))*(log(x)-mln).^2));
+diff_model = @(x,p,q)(x.^(p-1).*(1-x).^(q-1))/(beta(p,q));
+
 
 number_of_bins=length(centers_of_bins{2});
 spatial_correlations_centers=centers_of_bins{2};
@@ -30,24 +33,35 @@ if sum(spatial_correlations_distribution(spatial_correlations_centers<0.05))>0.0
     warning('A good fit might not be attainable because some of the cells seem to be smaller than expected. This could also occur if the provided microns per pixel ratio is incorrect or the maximal distance is too large')
 end
 
-% finding initial parameters for mle function:
-pdf_betamixture = @(x,p,A1,A2,B1,B2) ...
-    p*lognpdf(x,A1,B1) + (1-p)*betapdf(x,A2,B2);
-phat_same=lognfit(1-neighbors_spatial_correlations(neighbors_spatial_correlations>=0.7));
-phat_diff=betafit(neighbors_spatial_correlations(neighbors_spatial_correlations<0.7));
-pinitial_parameters=0.5;
-Ainitial_parameters=[phat_same(1) phat_diff(1)];
-Binitial_parameters=[phat_same(2) phat_diff(2)];
-initial_parameters=[pinitial_parameters Ainitial_parameters Binitial_parameters];
-lb = [0 -inf 0 0 0];
-ub = [1 Inf Inf Inf Inf];
-options = statset('MaxIter',1000, 'MaxFunEvals',2000);
+% finding initial parameters for EM:
+data = 1-neighbors_spatial_correlations;
+same_params=lognfit(data(neighbors_spatial_correlations>=0.7));
+mu = same_params(1); sigma = same_params(2);
+diff_params=betafit(neighbors_spatial_correlations(neighbors_spatial_correlations<0.7));
+p = diff_params(1); q = diff_params(2);
+PIsame = 0.5;
 
-% finding the parameters that best fit the data:
-spatial_correlations_model_parameters=mle(1-neighbors_spatial_correlations,'pdf',pdf_betamixture, 'start',initial_parameters, 'lower',lb, 'upper',ub,'options',options);
+
+%EM ALgorithm
+for i=1:100
+%E-step
+    assignments = PIsame*same_model(data,sigma,mu)...
+        ./(PIsame* same_model(data,sigma,mu)...
+        +(1-PIsame)*diff_model(data,p,q));
+
+    %M-step
+
+    PIsame = sum(assignments)/length(assignments);
+    mu = sum(assignments.*log(data))/sum(assignments);
+    sigma = sqrt(sum(assignments.*(log(data)-mu).^2)...
+        /sum(assignments));
+
+    [p,q] = estimate_beta_mixture_params(1-assignments,data,1);
+
+end
 
 % calculating the distribution for same cells:
-spatial_correlations_model_same_cells=lognpdf(1-spatial_correlations_centers,spatial_correlations_model_parameters(2),spatial_correlations_model_parameters(4));
+spatial_correlations_model_same_cells=lognpdf(1-spatial_correlations_centers,mu,sigma);
 spatial_correlations_model_same_cells=spatial_correlations_model_same_cells./sum(spatial_correlations_model_same_cells)*(number_of_bins/((spatial_correlations_centers(2)-spatial_correlations_centers(1))+(spatial_correlations_centers(end)-spatial_correlations_centers(1))));
 % the same cells model is multiplied by a sigmoid function because 
 %the lognormal ditribution goes to infinity but the correlation is bounded:
@@ -56,10 +70,10 @@ smoothing_func=sigmoid_function(spatial_correlations_centers,[20 min(spatial_cor
 spatial_correlations_model_same_cells=spatial_correlations_model_same_cells.*smoothing_func;
 spatial_correlations_model_same_cells(1:round(number_of_bins/10:end))=0;
 % calculating the distribution for different cells:
-spatial_correlations_model_different_cells=betapdf(1-spatial_correlations_centers,spatial_correlations_model_parameters(3),spatial_correlations_model_parameters(5));
+spatial_correlations_model_different_cells=betapdf(1-spatial_correlations_centers,p,q);
 spatial_correlations_model_different_cells=spatial_correlations_model_different_cells./sum(spatial_correlations_model_different_cells)*(number_of_bins/((spatial_correlations_centers(2)-spatial_correlations_centers(1))+(spatial_correlations_centers(end)-spatial_correlations_centers(1))));
 % calculating the weighted sum:
-spatial_correlations_model_weighted_sum=spatial_correlations_model_parameters(1)*spatial_correlations_model_same_cells+(1-spatial_correlations_model_parameters(1))*spatial_correlations_model_different_cells;
+spatial_correlations_model_weighted_sum=PIsame*spatial_correlations_model_same_cells+(1-PIsame)*spatial_correlations_model_different_cells;
 [spatial_correlations_distribution,~]=hist(neighbors_spatial_correlations,spatial_correlations_centers);
 spatial_correlations_distribution=spatial_correlations_distribution./sum(spatial_correlations_distribution)*(number_of_bins/((spatial_correlations_centers(2)-spatial_correlations_centers(1))+(spatial_correlations_centers(end)-spatial_correlations_centers(1))));
 
@@ -68,7 +82,7 @@ MSE_spatial_correlations_model=sum(abs(((spatial_correlations_distribution-spati
 
 % calculating the P_same of the model:
 minimal_p_same_threshold=0.001;
-p_same_given_spatial_correlation=spatial_correlations_model_parameters(1).*spatial_correlations_model_same_cells./(spatial_correlations_model_parameters(1).*spatial_correlations_model_same_cells+(1-spatial_correlations_model_parameters(1)).*spatial_correlations_model_different_cells);
+p_same_given_spatial_correlation=PIsame.*spatial_correlations_model_same_cells./(PIsame.*spatial_correlations_model_same_cells+(1-PIsame).*spatial_correlations_model_different_cells);
 indexes_to_smooth=find(spatial_correlations_model_same_cells<minimal_p_same_threshold*max(spatial_correlations_model_same_cells));
 sigmoid_function=@(x,ac)1./(1+exp(-ac(1)*(x-ac(2)))); % defining a sigmoid function
 smoothing_func=sigmoid_function(1:length(indexes_to_smooth),[0.05*length(indexes_to_smooth) 0.8*length(indexes_to_smooth)]);
@@ -77,8 +91,9 @@ p_same_given_spatial_correlation(indexes_to_smooth)=p_same_given_spatial_correla
 % finding the intersection between same cells and different cells:
 index_range_of_intersection=find(spatial_correlations_model_same_cells>minimal_p_same_threshold*max(spatial_correlations_model_same_cells));
 index_range_of_intersection(end)=[];
-[~,index_of_intersection]=min(abs(spatial_correlations_model_parameters(1)*spatial_correlations_model_same_cells(index_range_of_intersection)-(1-spatial_correlations_model_parameters(1))*spatial_correlations_model_different_cells(index_range_of_intersection)));
+[~,index_of_intersection]=min(abs(PIsame*spatial_correlations_model_same_cells(index_range_of_intersection)-(1-PIsame)*spatial_correlations_model_different_cells(index_range_of_intersection)));
 spatial_correlation_intersection=round(100*spatial_correlations_centers(index_of_intersection+index_range_of_intersection(1)-1))/100;
+spatial_correlations_model_parameters=[PIsame mu p sigma q];
 
 end
 

--- a/CellReg/estimate_beta_mixture_params.m
+++ b/CellReg/estimate_beta_mixture_params.m
@@ -1,0 +1,36 @@
+function [p,q] = estimate_beta_params(assignments,data,maximal_distance)
+% Estimates the parameters of an unstandard beta distribution
+% (one that ranges from [0,maximal_distance] using maximum
+% likelihood estimation via Newton-Raphson.
+%Note this is also used to fit the beta distribution in the spatial 
+%Correlation model. This is done by assigning maximal_distance to 1.
+
+           
+           %Values =maximal_distance will cause log(0)..bad.
+           data(data==maximal_distance)=0.9999*maximal_distance;
+           g1=sum(assignments.*log(data/maximal_distance))/sum(assignments);           
+           g2=sum(assignments.*log((maximal_distance-data)/maximal_distance))/sum(assignments);
+          %Initial guess via moment-matching         
+          
+           sample_mean = sum(assignments.*data)/sum(assignments);
+           sample_var = sum(assignments.*(data-sample_mean).^2)/sum(assignments);
+           
+           xbar = sample_mean/maximal_distance;
+           ssq= sample_var/(maximal_distance)^2;
+           
+           p = xbar*((xbar*(1-xbar)/ssq)-1);           
+           q = (1-xbar)*((xbar*(1-xbar)/ssq)-1);
+
+           x = [p;q];
+           %Newton-Raphson
+           for i=1:100
+               grad = [psi(p)-psi(p+q)-g1;psi(q)-psi(p+q)-g2];    
+
+               hess = [psi(1,p)-psi(1,p+q), -psi(1,p+q);-psi(1,p+q),psi(1,q)-psi(1,p+q)];
+               x= x-hess\grad;
+               p = x(1);
+               q=x(2);       
+           end
+   
+end
+


### PR DESCRIPTION
Updated `compute_spatial_correlations_model.m' to now fit the model via Expectation-Maximizaion (EM). This requires adding an extra file `estimate_beta_mixture_params.m', which is used in the Maximisation step of the algorithm. Tested on sample data with no errors.