### PR TITLE
Update compute_centroid_distances_model.m

### DIFF
--- a/CellReg/compute_centroid_distances_model.m
+++ b/CellReg/compute_centroid_distances_model.m
@@ -49,7 +49,7 @@ ub = [1 Inf Inf Inf Inf inf];
 options = statset('MaxIter',1000, 'MaxFunEvals',2000);
 
 % finding the parameters that best fit the data:
-options.algorithm=[];
+options.Algorithm=[];
 centroid_distances_model_parameters=lsqcurvefit(F,initial_parameters,microns_per_pixel*centroid_distances_centers,centroid_distances_distribution,lb,ub,options);
 
 % calculating the distribution for same cells:


### PR DESCRIPTION
For new matlab lsqcurvefit now has "options.algorithm" with a capital A. The code fails saying unrecognised field name "Algorithm" in options. So just initialising "options.Algorithm=[ ]" fixed it for me.

I have attached a screenshot of the error. I am very new to GitHub and programming, I hope this helps someone with the same problem and this is the right way to approach it.

<img width="383" alt="image" src="https://github.com/zivlab/CellReg/assets/86912401/aa420742-50b8-417c-a147-2f284e5bcff7">
