### PR TITLE
2 Bug Fixes

### DIFF
--- a/CellReg/compute_spatial_correlations_model.m
+++ b/CellReg/compute_spatial_correlations_model.m
@@ -94,7 +94,7 @@ spatial_correlations_model_different_cells=spatial_correlations_model_different_
 sigmoid_function=@(x,ac)1./(1+exp(-ac(1)*(x-ac(2)))); % defining the sigmoid function - (sigmf requires Fuzzy Logic Toolbox)
 smoothing_func=sigmoid_function(spatial_correlations_centers,[20 min(spatial_correlations_centers)+0.5]);
 spatial_correlations_model_same_cells=spatial_correlations_model_same_cells.*smoothing_func;
-spatial_correlations_model_same_cells(1:round(number_of_bins/10:end))=0;
+spatial_correlations_model_same_cells(1:round(number_of_bins/10))=0;
 
 % calculating the weighted sum:
 if ~isnan(p)

--- a/CellReg/plot_alignment_results.m
+++ b/CellReg/plot_alignment_results.m
@@ -41,8 +41,8 @@ end
 footprints_projections_corrected_rgb(footprints_projections_corrected_rgb>1)=1;
 footprints_projections_corrected_rgb=footprints_projections_corrected_rgb+0.25*max(max(max(footprints_projections_corrected_rgb)))*repmat(overlapping_FOV,1,1,3);
 
-figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility)
-set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+AlignFig=figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility);
+set(AlignFig,'CreateFcn','set(AlignFig,''Visible'',''on'')')
 subplot(2,2,1)
 imshow(footprints_projections_rgb)
 if number_of_sessions>2
@@ -96,15 +96,15 @@ set(gca,'xtick',[])
 set(gca,'ytick',[])
 legend(legend_strings)
 legend('boxoff')
-set(gcf,'PaperPositionMode','auto')
-savefig(fullfile(figures_directory,'Stage 2 - pre vs post alignment.fig'))
-saveas(gcf,fullfile(figures_directory,'Stage 2 - pre vs post alignment'),'png')
+set(AlignFig,'PaperPositionMode','auto')
+savefig(AlignFig,fullfile(figures_directory,'Stage 2 - pre vs post alignment.fig'))
+saveas(AlignFig,fullfile(figures_directory,'Stage 2 - pre vs post alignment'),'png')
 
 % Plotting measurments of preparation stability:
 if number_of_sessions>2
     % plottig the FOV correlations between all pairs of sessions:
-    figure('units','normalized','outerposition',[0.2 0.3 0.6 0.4],'Visible',figures_visibility)
-    set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+    AbnormalFig=figure('units','normalized','outerposition',[0.2 0.3 0.6 0.4],'Visible',figures_visibility);
+    set(AbnormalFig,'CreateFcn','set(AbnormalFig,''Visible'',''on'')')
     subplot(1,2,1)
     imagesc(all_centroid_projections_correlations)
     colormap('jet')
@@ -172,13 +172,13 @@ if number_of_sessions>2
     set(gca,'fontsize',14)
     xlabel('Session number','FontWeight','Bold','fontsize',14)
     ylabel('Maximal correlation','FontWeight','Bold','fontsize',14)
-    set(gcf,'PaperPositionMode','auto')
-    savefig(fullfile(figures_directory,'Stage 2 - abnormalities test - Correlations.fig'))
-    saveas(gcf,fullfile(figures_directory,'Stage 2 - abnormalities test - Correlations'),'png')
+    set(AbnormalFig,'PaperPositionMode','auto')
+    savefig(AbnormalFig,fullfile(figures_directory,'Stage 2 - abnormalities test - Correlations.fig'))
+    saveas(AbnormalFig,fullfile(figures_directory,'Stage 2 - abnormalities test - Correlations'),'png')
 end
 
-figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility)
-set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+AbnormalGenFig=figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility);
+set(AbnormalGenFig,'CreateFcn','set(AbnormalGenFig,''Visible'',''on'')')
 % plotting the translations for each session compared to the reference
 subplot(2,2,1)
 for n=1:number_of_sessions
@@ -306,9 +306,9 @@ x=1:number_of_sessions;
 set(gca,'XTick',x)
 set(gca,'XTickLabel',x_label,'fontsize',14,'fontweight','bold')
 set(gca,'fontsize',14)
-set(gcf,'PaperPositionMode','auto')
-savefig(fullfile(figures_directory,'Stage 2 - abnormalities test - general.fig'))
-saveas(gcf,fullfile(figures_directory,'Stage 2 - abnormalities test - general'),'png')
+set(AbnormalGenFig,'PaperPositionMode','auto')
+savefig(AbnormalGenFig,fullfile(figures_directory,'Stage 2 - abnormalities test - general.fig'))
+saveas(AbnormalGenFig,fullfile(figures_directory,'Stage 2 - abnormalities test - general'),'png')
 
 % if non-rigid transformation was used:
 if strcmp(alignment_type,'Non-rigid')
@@ -322,8 +322,8 @@ if strcmp(alignment_type,'Non-rigid')
     subx=4;
     suby=ceil(number_of_sessions/subx);
     if number_of_sessions>4
-        figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility)
-        set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+        NonRigidFig=figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility);
+        set(NonRigidFig,'CreateFcn','set(NonRigidFig,''Visible'',''on'')')
         for n=1:number_of_sessions
             subplot(suby,subx,n)
             quiver(x,y,squeeze(displacement_fields(n,(y_vector),(x_vector),1)),squeeze(flipud(displacement_fields(n,(y_vector),(x_vector),2))))
@@ -335,8 +335,8 @@ if strcmp(alignment_type,'Non-rigid')
             title(['Session ' num2str(n)],'fontsize',14,'fontweight','bold')
         end
     else
-        figure('units','normalized','outerposition',[0.1 0.2 0.8 0.5],'Visible',figures_visibility)
-        set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+        NonRigidFig=figure('units','normalized','outerposition',[0.1 0.2 0.8 0.5],'Visible',figures_visibility);
+        set(NonRigidFig,'CreateFcn','set(NonRigidFig,''Visible'',''on'')')
         for n=1:number_of_sessions
             subplot(1,number_of_sessions,n)
             quiver(x,y,squeeze(displacement_fields(n,(y_vector),(x_vector),1)),squeeze(flipud(displacement_fields(n,(y_vector),(x_vector),2))))
@@ -348,9 +348,9 @@ if strcmp(alignment_type,'Non-rigid')
             title(['Session ' num2str(n)],'fontsize',14,'fontweight','bold')
         end
     end
-    set(gcf,'PaperPositionMode','auto')
-    savefig(fullfile(figures_directory,'Stage 1 - Non-rigid transformations.fig'))
-    saveas(gcf,fullfile(figures_directory,'Stage 1 - Non-rigid transformations'),'png')    
+    set(NonRigidFig,'PaperPositionMode','auto')
+    savefig(NonRigidFig,fullfile(figures_directory,'Stage 1 - Non-rigid transformations.fig'))
+    saveas(NonRigidFig,fullfile(figures_directory,'Stage 1 - Non-rigid transformations'),'png')    
 end
     
 end

--- a/CellReg/plot_all_registered_projections.m
+++ b/CellReg/plot_all_registered_projections.m
@@ -56,8 +56,8 @@ end
 subx=4;
 suby=ceil(number_of_sessions/subx);
 if number_of_sessions>4
-    figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility)
-    set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+    ProjFig=figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility);
+    set(ProjFig,'CreateFcn','set(ProjFig,''Visible'',''on'')')
     for n=1:number_of_sessions
         subplot(suby,subx,n)
         imagesc(all_projections_partial{n})
@@ -71,8 +71,8 @@ if number_of_sessions>4
         end
     end
 else
-    figure('units','normalized','outerposition',[0.1 0.2 0.8 0.5],'Visible',figures_visibility)
-    set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+    ProjFig=figure('units','normalized','outerposition',[0.1 0.2 0.8 0.5],'Visible',figures_visibility);
+    set(ProjFig,'CreateFcn','set(ProjFig,''Visible'',''on'')')
     for n=1:number_of_sessions
         subplot(1,number_of_sessions,n)
         imagesc(all_projections_partial{n})
@@ -86,7 +86,7 @@ else
         end
     end
 end
-set(gcf,'PaperPositionMode','auto')
+set(ProjFig,'PaperPositionMode','auto')
 
 initial_stage=false;
 if ~isempty(varargin)
@@ -96,11 +96,11 @@ if ~isempty(varargin)
 end
 
 if initial_stage
-    savefig(fullfile(figures_directory,'Stage 4 - projcetions - initial registration.fig'))
-    saveas(gcf,fullfile(figures_directory,'Stage 4 - projcetions - initial registration'),'png')
+    savefig(ProjFig,fullfile(figures_directory,'Stage 4 - projcetions - initial registration.fig'))
+    saveas(ProjFig,fullfile(figures_directory,'Stage 4 - projcetions - initial registration'),'png')
 else
-    savefig(fullfile(figures_directory,'Stage 5 - projcetions - final registration.fig'))
-    saveas(gcf,fullfile(figures_directory,'Stage 5 - projcetions - final registration'),'png')    
+    savefig(ProjFig,fullfile(figures_directory,'Stage 5 - projcetions - final registration.fig'))
+    saveas(ProjFig,fullfile(figures_directory,'Stage 5 - projcetions - final registration'),'png')    
 end
 
 end

--- a/CellReg/plot_all_sessions_projections.m
+++ b/CellReg/plot_all_sessions_projections.m
@@ -11,8 +11,8 @@ number_of_sessions=size(footprints_projections,2);
 subx=4;
 suby=ceil(number_of_sessions/subx);
 if number_of_sessions>4
-    figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility)
-    set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+    FP_Fig=figure('units','normalized','outerposition',[0.1 0.1 0.8 0.8],'Visible',figures_visibility);
+    set(FP_Fig,'CreateFcn','set(FP_Fig,''Visible'',''on'')')
     for n=1:number_of_sessions
         subplot(suby,subx,n)
         imagesc(footprints_projections{n},[0 2])
@@ -22,8 +22,8 @@ if number_of_sessions>4
         title(['Session ' num2str(n)],'fontsize',14,'fontweight','bold')
     end
 else
-    figure('units','normalized','outerposition',[0.1 0.2 0.8 0.5],'Visible',figures_visibility)
-    set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+    FP_Fig=figure('units','normalized','outerposition',[0.1 0.2 0.8 0.5],'Visible',figures_visibility);
+    set(FP_Fig,'CreateFcn','set(FP_Fig,''Visible'',''on'')')
     for n=1:number_of_sessions
         subplot(1,number_of_sessions,n)
         imagesc(footprints_projections{n},[0 2])
@@ -33,9 +33,9 @@ else
         title(['Session ' num2str(n)],'fontsize',14,'fontweight','bold')
     end
 end
-set(gcf,'PaperPositionMode','auto')
-savefig(fullfile(figures_directory,'Stage 1 - spatial footprints projections.fig'))
-saveas(gcf,fullfile(figures_directory,'Stage 1 - spatial footprints projections'),'png')
+set(FP_Fig,'PaperPositionMode','auto')
+savefig(FP_Fig,fullfile(figures_directory,'Stage 1 - spatial footprints projections.fig'))
+saveas(FP_Fig,fullfile(figures_directory,'Stage 1 - spatial footprints projections'),'png')
 
 end
 

--- a/CellReg/plot_cell_scores.m
+++ b/CellReg/plot_cell_scores.m
@@ -17,9 +17,9 @@ number_of_clusters=size(cell_scores,2);
 number_of_bins=41;
 xout_temp=linspace(0,1,number_of_bins);
 xout=xout_temp(2:2:end);
-figure('units','normalized','outerposition',[0.25 0.2 0.5 0.6],'Visible',figures_visibility)
-set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
-set(gcf,'PaperOrientation','portrait');
+ScoreFig=figure('units','normalized','outerposition',[0.25 0.2 0.5 0.6],'Visible',figures_visibility);
+set(ScoreFig,'CreateFcn','set(ScoreFig,''Visible'',''on'')')
+set(ScoreFig,'PaperOrientation','portrait');
 size_x=0.65;
 size_y=0.65;
 
@@ -139,9 +139,9 @@ set(gca,'XTickLabel',x_label,'fontsize',14,'fontweight','bold')
 set(h, 'Xdir', 'reverse')
 xlabel('Score','fontsize',14,'fontweight','bold')
 ylabel('Cum. fraction','fontsize',14,'fontweight','bold')
-set(gcf,'PaperPositionMode','auto')
-savefig(fullfile(figures_directory,'Stage 5 - cell scores.fig'))
-saveas(gcf,fullfile(figures_directory,'Stage 5 - cell scores'),'png')
+set(ScoreFig,'PaperPositionMode','auto')
+savefig(ScoreFig,fullfile(figures_directory,'Stage 5 - cell scores.fig'))
+saveas(ScoreFig,fullfile(figures_directory,'Stage 5 - cell scores'),'png')
 
 % plotting the distribution of P_same for all registered cell-pairs
 number_of_sessions=size(p_same_registered_pairs{1},1);
@@ -159,7 +159,7 @@ for n=1:number_of_clusters
 end
 all_pairs_p_same(pair_count+1:end)=[];
 
-figure('units','normalized','outerposition',[0.35 0.3 0.3 0.4],'Visible',figures_visibility)
+PairFig=figure('units','normalized','outerposition',[0.35 0.3 0.3 0.4],'Visible',figures_visibility);
 [n1,~]=hist(all_pairs_p_same,xout);
 n1=n1./sum(n1);
 bar(xout,n1,1)
@@ -186,9 +186,9 @@ set(gca,'XTickLabel',x_label,'fontsize',14,'fontweight','bold')
 set(h, 'Xdir', 'reverse')
 xlabel('P_s_a_m_e','fontsize',14,'fontweight','bold')
 ylabel('Cum. fraction','fontsize',14,'fontweight','bold')
-set(gcf,'PaperPositionMode','auto')
-savefig(fullfile(figures_directory,'Stage 5 - Registered pairs P_same.fig'))
-saveas(gcf,fullfile(figures_directory,'Stage 5 - Registered pairs P_same'),'png')
+set(PairFig,'PaperPositionMode','auto')
+savefig(PairFig,fullfile(figures_directory,'Stage 5 - Registered pairs P_same.fig'))
+saveas(PairFig,fullfile(figures_directory,'Stage 5 - Registered pairs P_same'),'png')
 
 end
 

--- a/CellReg/plot_estimated_registration_accuracy.m
+++ b/CellReg/plot_estimated_registration_accuracy.m
@@ -6,8 +6,8 @@ number_of_p_same_bins=length(p_same_centers_of_bins);
 number_of_bins=length(centers_of_bins{1});
 p_same_certainty_threshold=1-p_same_certainty_threshold;
 
-figure('units','normalized','outerposition',[0.2 0.1 0.6 0.8],'Visible',figures_visibility)
-set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+RegFig=figure('units','normalized','outerposition',[0.2 0.1 0.6 0.8],'Visible',figures_visibility);
+set(RegFig,'CreateFcn','set(gcf,''Visible'',''on'')')
 size_x=0.78;
 size_y=0.78;
 p_same_given_spatial_correlation=varargin{1};
@@ -196,9 +196,9 @@ set(gca,'XTick',x)
 set(gca,'XTickLabel',x_label,'fontsize',14,'fontweight','bold')
 p=patch([0 1 1 0],[1 1 0 0],[0.8 0.8 0.8]);
 set(p,'FaceAlpha',0.3,'EdgeColor','none');
-set(gcf,'PaperPositionMode','auto')
-savefig(fullfile(figures_directory,'Stage 3 - registration certainty.fig'))
-saveas(gcf,fullfile(figures_directory,'Stage 3 - registration certainty'),'png')
+set(RegFig,'PaperPositionMode','auto')
+savefig(RegFig,fullfile(figures_directory,'Stage 3 - registration certainty.fig'))
+saveas(RegFig,fullfile(figures_directory,'Stage 3 - registration certainty'),'png')
 
 end
 

--- a/CellReg/plot_initial_registration.m
+++ b/CellReg/plot_initial_registration.m
@@ -18,8 +18,8 @@ registered_cells=varargin{1};
 non_registered_cells=varargin{2};
 
 if strcmp(initial_registration_type,'Spatial correlation') % if spatial correlations are used 
-    figure('units','normalized','outerposition',[0.3 0.25 0.4 0.5],'Visible',figures_visibility)
-    set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+    DiffFig=figure('units','normalized','outerposition',[0.3 0.25 0.4 0.5],'Visible',figures_visibility);
+    set(DiffFig,'CreateFcn','set(DiffFig,''Visible'',''on'')')
     xout=linspace(0,1,number_of_bins);
     [n1,~]=hist(registered_cells,xout);
     [n2,~]=hist(non_registered_cells,xout);
@@ -40,8 +40,8 @@ if strcmp(initial_registration_type,'Spatial correlation') % if spatial correlat
 else
     pixel_to_mic=varargin{3};
     maximal_distance=varargin{4};    
-    figure('units','normalized','outerposition',[0.3 0.25 0.4 0.5],'Visible',figures_visibility)
-    set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+    DiffFig=figure('units','normalized','outerposition',[0.3 0.25 0.4 0.5],'Visible',figures_visibility);
+    set(DiffFig,'CreateFcn','set(DiffFig,''Visible'',''on'')')
     xout=linspace(0,maximal_distance,number_of_bins);
     [n1,~]=hist(registered_cells,xout);
     [n2,~]=hist(non_registered_cells,xout);
@@ -59,9 +59,9 @@ else
     legend('Same Cell','Different Cells','location','northwest')
     legend('boxoff')
 end
-set(gcf,'PaperPositionMode','auto')
-savefig(fullfile(figures_directory,'Stage 4 - same versus different cells.fig'))
-saveas(gcf,fullfile(figures_directory,'Stage 4 - same versus different cells'),'png')
+set(DiffFig,'PaperPositionMode','auto')
+savefig(DiffFig,fullfile(figures_directory,'Stage 4 - same versus different cells.fig'))
+saveas(DiffFig,fullfile(figures_directory,'Stage 4 - same versus different cells'),'png')
 
 % Plotting the registration results with the cell maps from all sessions:
 is_initial_stage=true;

--- a/CellReg/plot_models.m
+++ b/CellReg/plot_models.m
@@ -17,8 +17,8 @@ end
 
 number_of_bins=length(centers_of_bins{1});
 
-figure('units','normalized','outerposition',[0.2 0.1 0.6 0.8],'Visible',figures_visibility)
-set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
+ModelFig=figure('units','normalized','outerposition',[0.2 0.1 0.6 0.8],'Visible',figures_visibility);
+set(ModelFig,'CreateFcn','set(ModelFig,''Visible'',''on'')')
 if ~isempty(varargin)
     subplot(2,2,2)
     [n1,~]=hist(NN_spatial_correlations,centers_of_bins{2});
@@ -34,7 +34,7 @@ if ~isempty(varargin)
     set(gca,'fontsize',14)
     set(gca,'XTick',x)
     set(gca,'XTickLabel',x_label,'fontsize',14)
-    set(gcf,'PaperPositionMode','auto')
+    set(ModelFig,'PaperPositionMode','auto')
     xlabel('Spatial correlation','FontWeight','Bold','fontsize',14)
     ylabel('Number of cell-pairs','FontWeight','Bold','fontsize',14)
     set(gca,'fontsize',14)
@@ -119,9 +119,9 @@ text(centroid_distance_intersection+1,0.9*max(centroid_distances_distribution),[
 text(centroid_distance_intersection-1,0.9*max(centroid_distances_distribution),[num2str(round(100*(1-same_more_than_thresh))) '%'],'fontsize',14,'fontweight','bold','HorizontalAlignment','Center','color','g')
 text(centroid_distance_intersection+1,0.8*max(centroid_distances_distribution),[num2str(round(100*(diff_more_than_thresh))) '%'],'fontsize',14,'fontweight','bold','HorizontalAlignment','Center','color','r')
 text(centroid_distance_intersection-1,0.8*max(centroid_distances_distribution),[num2str(round(100*(1-diff_more_than_thresh))) '%'],'fontsize',14,'fontweight','bold','HorizontalAlignment','Center','color','r')
-set(gcf,'PaperPositionMode','auto')
-savefig(fullfile(figures_directory,'Stage 3 - model.fig'))
-saveas(gcf,fullfile(figures_directory,'Stage 3 - model'),'png')
+set(ModelFig,'PaperPositionMode','auto')
+savefig(ModelFig,fullfile(figures_directory,'Stage 3 - model.fig'))
+saveas(ModelFig,fullfile(figures_directory,'Stage 3 - model'),'png')
 
 end
 

--- a/CellReg/plot_x_y_displacements.m
+++ b/CellReg/plot_x_y_displacements.m
@@ -21,9 +21,9 @@ x_y_displacements=hist3([neighbors_x_displacements;neighbors_y_displacements]',c
 x_y_displacements=flipud(x_y_displacements);
 x_y_displacements=fliplr(x_y_displacements);
 
-figure('units','normalized','outerposition',[0.35 0.25 0.3 0.5],'Visible',figures_visibility)
-set(gcf,'CreateFcn','set(gcf,''Visible'',''on'')')
-set(gcf,'PaperOrientation','portrait');
+DisplaceFig=figure('units','normalized','outerposition',[0.35 0.25 0.3 0.5],'Visible',figures_visibility);
+set(DisplaceFig,'CreateFcn','set(DisplaceFig,''Visible'',''on'')')
+set(DisplaceFig,'PaperOrientation','portrait');
 size_x=0.75;
 size_y=0.75;
 axes('position',[0.12 0.15 size_x size_y])
@@ -59,9 +59,9 @@ text(3.5,0.5,'Number of cell-pairs (log)','fontsize',14,'fontweight','bold','rot
 text(1.5,0,'0','fontsize',14,'fontweight','bold','HorizontalAlignment','Left')
 text(1.5,1,'Max','fontsize',14,'fontweight','bold','HorizontalAlignment','Left')
 set(gca,'fontsize',14)
-set(gcf,'PaperPositionMode','auto')
-savefig(fullfile(figures_directory,'Stage 3 - (x,y) displacements.fig'))
-saveas(gcf,fullfile(figures_directory,'Stage 3 - (x,y) displacements'),'png')
+set(DisplaceFig,'PaperPositionMode','auto')
+savefig(DisplaceFig,fullfile(figures_directory,'Stage 3 - (x,y) displacements.fig'))
+saveas(DisplaceFig,fullfile(figures_directory,'Stage 3 - (x,y) displacements'),'png')
 
 end
 


### PR DESCRIPTION
A handful of small edits designed to fix 2 bugs.

The first bug is in compute_spatial_correlations_model.m: in line 97, ```1:round(number_of_bins/10:end)``` is likely erroneous. Effectively, this is 1:(X:end), and Matlab coerces that to 1:X, and in 2024a, generates a warning about colon operands. Removing the ```:end``` heads that off, and prevents the warning.

The second bug is more complicated, and may be a weird interaction between Matlab and Ubuntu. Effectively, when running CellReg on Ubuntu 24.04 (tested on Matlab 2023b and 2024a), a strange behavior happens where some calls of ```savefig()``` cause focus to be pulled away from the target figure and onto the GUI, which ```savefig()``` then attempts to save. In the best case scenario, this results in an image of the GUI being saved instead of the target figure. In the worst case scenario, when ```savefig()``` attempts to save the GUI elements, it creates an additional conflict with the core Matlab function ```write()```, causing an error that breaks the analysis.

Adding ```gcf``` as an argument to ```savefig()``` does not fix this behavior. Instead, for each instance of ```savefig()```, adding a persistent for each figure to be saved using ```FigName = gcf``` or ```FigName = figure();``` and then using that as the target for ```savefig()```, and other ```gcf``` uses, fixes the issue. I didn't encounter this bug every time ```savefig()``` was called, but applying the fix to every instance seemed like a good preventative measure.