### PR TITLE
Fix align_images crash when correlation peak lands at the search-window edge

### DIFF
--- a/CellReg/align_images.m
+++ b/CellReg/align_images.m
@@ -292,6 +292,20 @@ else
         
         % finding the best translation with a gaussian fit:
         gaussian_radius=round(1.5*normalized_typical_cell_size);
+        % Edge guard: for a session that does not overlap the reference, the
+        % correlation peak (x_ind,y_ind) can land within gaussian_radius of the
+        % cross_corr_partial border, making the sub-pixel window indices below
+        % (e.g. x_ind-gaussian_radius, x_ind-1) non-positive and aborting MATLAB
+        % with "Array indices must be positive integers". That crash happens
+        % before the maximal_cross_correlation resemblance gate further down can
+        % reject the session gracefully. Clamp the peak into the interior so the
+        % sub-pixel fit is always in-bounds; a genuinely non-resembling session
+        % still fails that gate and is added to bad_algn_sessions as before. For
+        % a well-aligned session the peak sits near the centre of
+        % cross_corr_partial, so the clamp is a no-op.
+        [cross_corr_partial_height,cross_corr_partial_width]=size(cross_corr_partial);
+        x_ind=min(max(x_ind,gaussian_radius+1),cross_corr_partial_width-gaussian_radius);
+        y_ind=min(max(y_ind,gaussian_radius+1),cross_corr_partial_height-gaussian_radius);
         temp_corr_x=cross_corr_partial(y_ind-1:y_ind+1,x_ind-gaussian_radius:x_ind+gaussian_radius);
         sigma_0=normalized_typical_cell_size/5;
         [~,mu_x_1]=gaussfit(-gaussian_radius:gaussian_radius,temp_corr_x(1,:)./sum(temp_corr_x(1,:)),sigma_0,0);


### PR DESCRIPTION
When a session does not overlap the reference well, the FOV cross-correlation peak `(x_ind, y_ind)` within `cross_corr_partial` can fall within `gaussian_radius` of the border. The sub-pixel gaussian-fit windows that follow —

```matlab
temp_corr_x=cross_corr_partial(y_ind-1:y_ind+1,x_ind-gaussian_radius:x_ind+gaussian_radius);
temp_corr_y=cross_corr_partial(y_ind-gaussian_radius:y_ind+gaussian_radius,x_ind-1:x_ind+1);
```

— then index with a non-positive subscript and MATLAB aborts:

```
Index in position 1 is invalid. Array indices must be positive integers or logical values.
Error in align_images (sub-pixel fit)
```

Because this abort happens *before* the `maximal_cross_correlation` resemblance gate that would otherwise reject the session, a single non-resembling session crashes the entire multi-session registration instead of being dropped as a bad alignment.

### Fix
Clamp the peak into the interior of `cross_corr_partial` before the sub-pixel fit so the window is always in bounds:

```matlab
[cross_corr_partial_height,cross_corr_partial_width]=size(cross_corr_partial);
x_ind=min(max(x_ind,gaussian_radius+1),cross_corr_partial_width-gaussian_radius);
y_ind=min(max(y_ind,gaussian_radius+1),cross_corr_partial_height-gaussian_radius);
```

A genuinely non-resembling session still fails the resemblance gate and is added to `bad_algn_sessions` exactly as before; for a well-aligned session the peak sits near the centre of `cross_corr_partial`, so the clamp is a no-op and results are unchanged.

### How it was hit
Cross-session registration of a multi-session dataset with substantial day-to-day FOV drift (some sessions overlapping the reference only marginally). The marginal sessions are the ones whose peak lands at the edge.